### PR TITLE
Support multiple send types from ViewBlock

### DIFF
--- a/src/thorchain-exporter/BaseMapper.ts
+++ b/src/thorchain-exporter/BaseMapper.ts
@@ -1,7 +1,7 @@
 import {ViewblockEvent, ViewblockEventSend, ViewblockTx} from "../viewblock";
 import {CryptoTaxTransaction, CryptoTaxTransactionType} from "../cryptotax";
 import assert from "assert";
-import {TypeMsgSend, ViewblockMsg, ViewblockTxV2} from "../viewblock";
+import {TypeMsgSends, ViewblockMsg, ViewblockTxV2} from "../viewblock";
 
 // 0.02 RUNE
 const DEFAULT_RUNE_GAS = '2000000';
@@ -42,7 +42,7 @@ export class BaseMapper implements IThorchainMapper {
 
         // mapping new tx format to old format
 
-        const msgs = this.tx.msgs.filter(msg => msg['@type'] === TypeMsgSend);
+        const msgs = this.tx.msgs.filter(msg => TypeMsgSends.includes(msg['@type']));
         assert.equal(msgs.length, 1);
 
         const msg: ViewblockMsg = msgs[0];

--- a/src/viewblock/ViewblockTxV2.ts
+++ b/src/viewblock/ViewblockTxV2.ts
@@ -1,5 +1,8 @@
 
-export const TypeMsgSend = '/types.MsgSend';
+export const TypeMsgSends = [
+    '/cosmos.bank.v1beta1.MsgSend',
+    '/types.MsgSend'
+]
 
 export interface ViewblockTxV2 {
     blockIndex: number;
@@ -26,7 +29,7 @@ export interface ViewblockTxV2 {
 }
 
 export interface ViewblockMsg {
-    "@type": string;      // "/types.MsgSend"
+    "@type": string;      // see TypeMsgSends array for possibilities
     from_address: string;
     to_address: string;
     amount: {

--- a/test/SendMapper.test.ts
+++ b/test/SendMapper.test.ts
@@ -104,6 +104,65 @@ describe('SendMapper', () => {
         ]);
     });
 
+    test('send 0.00000001 RUNE to self for arkeo wallet delegation (alternate @type)', () => {
+        const tx: any = {
+            "blockIndex": 0,
+            "code": 0,
+            "height": 10000000,
+            "input": {
+                "chain": "THOR",
+                "asset": "THOR.RUNE",
+                "amount": "1",
+                "type": null,
+                "usdNew": "0.00000001",
+                "usd": "0"
+            },
+            "memo": "delegate:arkeo:arkeo1-user-wallet-11111",
+            "msgs": [
+                {
+                    "@type": "/cosmos.bank.v1beta1.MsgSend",
+                    "from_address": "thor1-user-wallet-11111",
+                    "to_address": "thor1-user-wallet-11111",
+                    "amount": [
+                        {
+                            "denom": "rune",
+                            "amount": "1"
+                        }
+                    ]
+                }
+            ],
+            "signer": "thor1-user-wallet-11111",
+            "status": "success",
+            "timestamp": 1609419600000,
+            "types": [
+                "network",
+                "send",
+                "main"
+            ],
+            "hash": "0000000000000000000000000000000000000000000000000000000000000000"
+        };
+
+        mapper = new SendMapper(tx, 'thor1-user-wallet-11111');
+        const ctc = mapper.toCtc();
+
+        expect(ctc).toStrictEqual([
+            {
+                "baseAmount": "0.00000001",
+                "baseCurrency": "RUNE",
+                "blockchain": "THOR",
+                "description": "Send 0.00000001 RUNE; 0000000000000000000000000000000000000000000000000000000000000000",
+                "feeAmount": "0.02",
+                "feeCurrency": "RUNE",
+                "from": "thor1-user-wallet-11111",
+                "id": "2020-12-31T13:00:00.000Z.send",
+                "timestamp": "2020-12-31T13:00:00.000Z",
+                "to": "thor1-user-wallet-11111",
+                "type": "send",
+                "walletExchange": "thor1-user-wallet-11111"
+            }
+        ]);
+    });
+
     test('Send TCY', () => {
         const tx = getTestData('viewblock/Send_TCY');
         mapper = new SendMapper(tx, 'thor1-user-wallet-11111');


### PR DESCRIPTION
I've seen cases where ViewBlock is returning /cosmos.bank.v1beta1.MsgSend for basic RUNE sends, so add support for it.

An example txn is 31B8A124ACC008BA85CA423F4A19E01EC91CDA7A02203C66C8ABA8503C3E8AC3